### PR TITLE
Fix for run.sh so that modules load

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,9 +6,10 @@ echo "OS Version is $OS_VERSION"
 modprobe i2c-dev
 
 mod_dir="seeed-voicecard_${BALENA_DEVICE_TYPE}_${OS_VERSION}*"
+echo "Loading snd-soc-simple-card first..."
+modprobe snd-soc-simple-card
 for each in $mod_dir; do
 	echo Loading module from "$each"
-	cp "$each/snd-soc-ac108.ko"
 	insmod "$each/snd-soc-ac108.ko"
 	insmod "$each/snd-soc-wm8960.ko"
 	insmod "$each/snd-soc-seeed-voicecard.ko"


### PR DESCRIPTION
This PR fixes a few problems with `run.sh`:

- Set perms to 755 rather than 644
- Don't run `cp` without a destination
- These modules depend on snd-doc-simple-card, so modprobe that first

The end result is that, on my Raspberry Pi 4, the seeed modules appear to load:

```
root@82b5ba9:~# lsmod | grep snd_
snd_soc_ac108          65536  0
snd_soc_seeed_voicecard    16384  1 snd_soc_ac108
snd_soc_simple_card    16384  0
snd_soc_simple_card_utils    16384  2 snd_soc_seeed_voicecard,snd_soc_simple_card
snd_soc_wm8960         49152  0
snd_bcm2835            28672  0
snd_soc_core          217088  6 snd_soc_seeed_voicecard,vc4,snd_soc_ac108,snd_soc_simple_card_utils,snd_soc_simple_card,snd_soc_wm8960
snd_compress           20480  1 snd_soc_core
snd_pcm_dmaengine      16384  1 snd_soc_core
snd_pcm               126976  5 vc4,snd_bcm2835,snd_soc_core,snd_soc_wm8960,snd_pcm_dmaengine
snd_timer              40960  1 snd_pcm
snd                    86016  6 snd_bcm2835,snd_timer,snd_compress,snd_soc_core,snd_pcm,snd_soc_wm8960
```
A couple of notes:

- I'm not sure what the `cp` was for, and it did not have a destination...so I left it out.  

- It looks like we don't need to insmod seeed-voicecard -- judging from the container logs, it's pulled in automatically (output below).  I've left this line in case I'm missing something.

```
11.05.20 12:51:21 (-0700)  main  OS Version is 2.48.0+rev1
11.05.20 12:51:21 (-0700)  main  Loading snd-soc-simple-card first...
11.05.20 12:51:21 (-0700)  main  Loading module from seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev/snd-soc-ac108.ko: File exists
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev/snd-soc-wm8960.ko: File exists
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev/snd-soc-seeed-voicecard.ko: File exists
11.05.20 12:51:21 (-0700)  main  Loading module from seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev_from_src
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev_from_src/snd-soc-ac108.ko: File exists
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev_from_src/snd-soc-wm8960.ko: File exists
11.05.20 12:51:21 (-0700)  main  insmod: ERROR: could not insert module seeed-voicecard_raspberrypi4-64_2.48.0+rev1.dev_from_src/snd-soc-seeed-voicecard.ko: File exists
```

- It looks like this may not be the most up-to-date version of [the seeed drivers](https://github.com/respeaker/seeed-voicecard).  I realized this when I found a bug in [seeed-voicecard/Makefile](https://github.com/balena-io-playground/hear/blob/master/seeed-voicecard/Makefile#L32-L33) included in this repo; I've filed an issue for this here for your reference, but this bug is *not* found upstream.  I'll leave it to you to figure out if you need to pull in a more recent version.

Hope this helps, and please let me know if you need any further info!

Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>